### PR TITLE
Fix docs for get_locale and put_locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   wrapping at the 80th column
 * Parse multiple references in the same reference comment
 * Remove `Gettext.locale/0-1` and `Gettext.with_locale/2` in favour of
-  `Gettext.put_locale/2`, `Gettext.get_locale/2`, and `Gettext.with_locale/3`
+  `Gettext.get_locale/1`, `Gettext.put_locale/2`, and `Gettext.with_locale/3`
   which now work by setting/getting the locale on a per-backend basis (instead
   of a global one)
 * Remove the `:default_locale` config option for the `:gettext` application in

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -420,9 +420,9 @@ defmodule Gettext do
 
   ## Examples
 
-      Gettext.put_locale("pt_BR")
+      Gettext.put_locale(MyApp.Gettext, "pt_BR")
       #=> nil
-      Gettext.get_locale()
+      Gettext.get_locale(MyApp.Gettext)
       #=> "pt_BR"
 
   """


### PR DESCRIPTION
The backend parameter was missing in some examples.
